### PR TITLE
Fix viewport madness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,15 +1,11 @@
 
-html, body {
-    /* make the document at least as tall as the viewport */
-    height: 100%;
-}
-
 body {
     /* Make the body content align to the bottom of the screen */
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
+    height: 100%;
 }
 
 .main {

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 <head>
     <title>Kickball Clicker</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <meta name="viewport? content=" width=device-width, user-scalable=no" />
+    <meta name="viewport" content="width=500, height=580" />
     <link rel="manifest" href="manifest.json" />
 </head>
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 <head>
     <title>Kickball Clicker</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport? content=" width=device-width, user-scalable=no" />
     <link rel="manifest" href="manifest.json" />
 </head>
 


### PR DESCRIPTION
I 'fixed' the meta viewport tag, but didn't actually test on my phone.

For some reason having `html` with `height: 100%` broke scrolling. Not sure why. Seems to work with just the body at `height: 100%`.

I set the viewport size to 500x580, which is roughly what the header + table UI ends up rendering as. If we add more UI or change the size we'll need to update those values, or investigate the proper combination of `width=device-width, initial-scale=??`

But this works for now.

![IMG_1A559269000C-1](https://user-images.githubusercontent.com/2774632/233749577-5ee34b3d-c301-4ba4-a31d-382e3936654e.jpeg)
